### PR TITLE
Standardize module name to follow an all uppercase convention

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -18,7 +18,7 @@ public class AddPersonCommand extends Command {
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_MODULE + "ADDRESS "
+            + PREFIX_MODULE + "MODULE "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.*;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -36,7 +37,7 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Module module = ParserUtil.parseModule(argMultimap.getValue(PREFIX_MODULE).get());
+        Module module = ParserUtil.parseModule(argMultimap.getValue(PREFIX_MODULE).get().toUpperCase(Locale.ROOT));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Person person = new Person(name, email, module, tagList);

--- a/src/main/java/seedu/address/logic/parser/FindPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPersonCommandParser.java
@@ -5,6 +5,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -152,7 +153,7 @@ public class FindPersonCommandParser implements Parser<FindPersonCommand> {
 
         pattern = Pattern.compile(VALIDATION_REGEX);
         for (String s : modules) {
-            matcher = pattern.matcher(s);
+            matcher = pattern.matcher(s.toUpperCase(Locale.ROOT));
             if (!matcher.find() && !Objects.equals(s, "")) {
                 throw new ParseException(MESSAGE_CONSTRAINTS);
             }

--- a/src/main/java/seedu/address/model/person/Module.java
+++ b/src/main/java/seedu/address/model/person/Module.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import java.util.Locale;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
@@ -19,7 +21,7 @@ public class Module {
      * if the module code matches a 2/3 letter - 4 number - optional one letter pattern.
      *
      */
-    public static final String VALIDATION_REGEX = "([a-zA-Z]{2,3})([0-9]{4})([a-zA-Z])?";
+    public static final String VALIDATION_REGEX = "([A-Z]{2,3})([0-9]{4})([A-Z])?";
 
     public final String moduleCode;
 
@@ -30,6 +32,7 @@ public class Module {
      */
     public Module(String module) {
         requireNonNull(module);
+        module = module.toUpperCase(Locale.ROOT);
         checkArgument(isValidModule(module), MESSAGE_CONSTRAINTS);
         moduleCode = module;
     }


### PR DESCRIPTION
Fixes #94 
Standardize module name to follow an all uppercase convention in display
Allow flexibility for users to enter all lowercase modules but reflect and taken in as all uppercase module
Parse the modules based on uppercase convention only