### PR TITLE
Allow wrap text for name, description and email for better viewability

### DIFF
--- a/src/main/resources/view/AssignmentListCard.fxml
+++ b/src/main/resources/view/AssignmentListCard.fxml
@@ -25,7 +25,7 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="description" text="\$description" styleClass="cell_big_label" />
+                <Label fx:id="description" text="\$description" styleClass="cell_big_label" wrapText="true"/>
             </HBox>
             <FlowPane fx:id="status" />
             <Label fx:id="dueDate" styleClass="cell_small_label" text="\$dueDate" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -25,11 +25,11 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true"/>
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="module" styleClass="cell_small_label" text="\$module" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
fixes #231 
Improve the viewablity of TA^2 in case users have really long inputs

![image](https://user-images.githubusercontent.com/62885511/140000877-e9968087-0bbf-4735-901d-0fe7840bbaa5.png)