### PR TITLE
Change name for filtered assignment list method in logic

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -49,6 +49,6 @@ public interface Logic {
      */
     void setGuiSettings(GuiSettings guiSettings);
 
-    /** Returns an unmodifiable view of the filtered list of assignments */
-    ObservableList<Assignment> getFilteredAssignmentList();
+    /** Returns an unmodifiable view of the list of assignments */
+    ObservableList<Assignment> getAssignmentList();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -85,7 +85,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Assignment> getFilteredAssignmentList() {
+    public ObservableList<Assignment> getAssignmentList() {
         return model.getAssignmentList();
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -117,7 +117,7 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
-        assignmentListPanel = new AssignmentListPanel(logic.getFilteredAssignmentList());
+        assignmentListPanel = new AssignmentListPanel(logic.getAssignmentList());
         assignmentListPanelPlaceholder.getChildren().add(assignmentListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();


### PR DESCRIPTION
One more last refactor to get rid of filteredAssignmentList name